### PR TITLE
Device assignment and unassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show which MDM server a device is assigned to
 - Show the ID of the MDM server a device is assigned to
 - Show information about the MDM server a device is assigned to
+- Assign and unassign devices to MDM servers
 
 ## 0.1.2 - 2025-07-14
 

--- a/lib/axm/client.rb
+++ b/lib/axm/client.rb
@@ -165,5 +165,30 @@ module Axm
 
       [response_json, response.code]
     end
+
+    # Sends a POST request to the specified URI with given parameters.
+    #
+    # @param uri [String, URI] The endpoint URI.
+    # @param request_body [Hash] Parameters to include in the request body.
+    # @return [Hash, Integer] The HTTP response object and status code.
+    def post(path, request_body = {})
+      uri = URI("https://#{api_domain}/#{path}")
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+
+      request = Net::HTTP::Post.new(uri)
+      request['Host'] = uri.host
+      request['Content-Type'] = 'application/json'
+      request['Authorization'] = "Bearer #{access_token['access_token']}"
+
+      request.body = request_body.to_json unless request_body.empty?
+
+      response = http.request(request)
+
+      response_body = JSON.parse(response.body)
+
+      [response_body, response.code]
+    end
   end
 end

--- a/lib/axm/client.rb
+++ b/lib/axm/client.rb
@@ -89,15 +89,7 @@ module Axm
         return cached_access_token unless token_expired
       end
 
-      params = {
-        grant_type: 'client_credentials',
-        client_id: @client_id,
-        client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-        client_assertion: client_assertion,
-        scope: "#{scope}.api"
-      }
-
-      response = post('https://account.apple.com/auth/oauth2/v2/token', params)
+      response = exchange_access_token_request
 
       response_body = response.first if response.last.to_i == 200
 
@@ -141,20 +133,27 @@ module Axm
       JSON.parse(res.body)
     end
 
-    # Sends a POST request to the specified URI with given parameters.
+    # Sends a POST request to exchange the credentials for an access token.
     #
-    # @param uri [String, URI] The endpoint URI.
-    # @param params [Hash] Parameters to include in the request body.
-    # @return [Net::HTTPResponse] The HTTP response object.
-    def post(uri, params = {})
-      uri = URI(uri) if uri.is_a?(String)
+    # @return [Net::HTTPResponse, integer] The HTTP response object and status code.
+    def exchange_access_token_request
+      uri = URI('https://account.apple.com/auth/oauth2/v2/token')
+
+      request_body = {
+        grant_type: 'client_credentials',
+        client_id: @client_id,
+        client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        client_assertion: client_assertion,
+        scope: "#{scope}.api"
+      }
+
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
 
       request = Net::HTTP::Post.new(uri)
       request['Host'] = uri.host
       request['Content-Type'] = 'application/x-www-form-urlencoded'
-      request.body = URI.encode_www_form(params) unless params.empty?
+      request.body = URI.encode_www_form(request_body)
 
       response = http.request(request)
 

--- a/lib/axm/client/organization_device_activities.rb
+++ b/lib/axm/client/organization_device_activities.rb
@@ -12,6 +12,40 @@ module Axm
       def org_device_activity(activity_id, options = {})
         get("v1/orgDeviceActivities/#{activity_id}", options)
       end
+
+      # Assigns a device to an MDM server.
+      #
+      # @param device_id [String] The unique identifier of the device to be assigned.
+      # @param mdm_server_id [String] The unique identifier of the MDM server to which the device will be assigned.
+      # @return [Hash, Integer] The response from the POST method, containing details of the assignment and status code.
+      def assign(device_id, mdm_server_id)
+        request_body = {
+          data: {
+            type: "orgDeviceActivities",
+            attributes: {
+              activityType: "ASSIGN_DEVICES"
+            },
+            relationships: {
+              mdmServer: {
+                data: {
+                  type: "mdmServers",
+                  id: mdm_server_id
+                }
+              },
+              devices: {
+                data: [
+                  {
+                    type: "orgDevices",
+                    id: device_id
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        post("v1/orgDeviceActivities", request_body)
+      end
     end
   end
 end

--- a/lib/axm/client/organization_device_activities.rb
+++ b/lib/axm/client/organization_device_activities.rb
@@ -19,11 +19,32 @@ module Axm
       # @param mdm_server_id [String] The unique identifier of the MDM server to which the device will be assigned.
       # @return [Hash, Integer] The response from the POST method, containing details of the assignment and status code.
       def assign(device_id, mdm_server_id)
+        assignment_change(device_id, mdm_server_id, "ASSIGN_DEVICES")
+      end
+
+      # Unassigns a device from an MDM server.
+      #
+      # @param device_id [String] The unique identifier of the device to be assigned.
+      # @param mdm_server_id [String] The unique identifier of the MDM server to which the device will be assigned.
+      # @return [Hash, Integer] The response from the POST method, containing details of the assignment and status code.
+      def unassign(device_id, mdm_server_id)
+        assignment_change(device_id, mdm_server_id, "UNASSIGN_DEVICES")
+      end
+
+      private
+
+      # Sends a request to change the assignment of a device to an MDM server.
+      #
+      # @param device_id [String] The unique identifier of the device.
+      # @param mdm_server_id [String] The unique identifier of the MDM server.
+      # @param activity_type [String] The type of activity being performed (e.g., "ASSIGN_DEVICES", "UNASSIGN_DEVICES").
+      # @return [Hash, Integer] The response from the POST request, containing details of the operation and status code.
+      def assignment_change(device_id, mdm_server_id, activity_type)
         request_body = {
           data: {
             type: "orgDeviceActivities",
             attributes: {
-              activityType: "ASSIGN_DEVICES"
+              activityType: activity_type
             },
             relationships: {
               mdmServer: {

--- a/lib/axm/client/organization_device_activities.rb
+++ b/lib/axm/client/organization_device_activities.rb
@@ -15,7 +15,7 @@ module Axm
 
       # Assigns a device to an MDM server.
       #
-      # @param device_id [String] The unique identifier of the device to be assigned.
+      # @param device_ids [Array<String>] Array of device IDs to be assigned.
       # @param mdm_server_id [String] The unique identifier of the MDM server to which the device will be assigned.
       # @return [Hash, Integer] The response from the POST method, containing details of the assignment and status code.
       def assign(device_id, mdm_server_id)
@@ -24,7 +24,7 @@ module Axm
 
       # Unassigns a device from an MDM server.
       #
-      # @param device_id [String] The unique identifier of the device to be assigned.
+      # @param device_ids [Array<String>] Array of device IDs to be unassigned.
       # @param mdm_server_id [String] The unique identifier of the MDM server to which the device will be assigned.
       # @return [Hash, Integer] The response from the POST method, containing details of the assignment and status code.
       def unassign(device_id, mdm_server_id)
@@ -35,11 +35,18 @@ module Axm
 
       # Sends a request to change the assignment of a device to an MDM server.
       #
-      # @param device_id [String] The unique identifier of the device.
+      # @param device_ids [Array<String>] Array of IDs of devices to be assigned or unassigned.
       # @param mdm_server_id [String] The unique identifier of the MDM server.
-      # @param activity_type [String] The type of activity being performed (e.g., "ASSIGN_DEVICES", "UNASSIGN_DEVICES").
+      # @param activity_type [String] The type of activity being performed ("ASSIGN_DEVICES" or "UNASSIGN_DEVICES").
       # @return [Hash, Integer] The response from the POST request, containing details of the operation and status code.
-      def assignment_change(device_id, mdm_server_id, activity_type)
+      def assignment_change(device_ids, mdm_server_id, activity_type)
+        devices = device_ids.map do |device_id|
+          {
+            type: "orgDevices",
+            id: device_id
+          }
+        end
+
         request_body = {
           data: {
             type: "orgDeviceActivities",
@@ -54,12 +61,7 @@ module Axm
                 }
               },
               devices: {
-                data: [
-                  {
-                    type: "orgDevices",
-                    id: device_id
-                  }
-                ]
+                data: devices
               }
             }
           }


### PR DESCRIPTION
Devices can be assigned and unassigned from MDM servers.

Multiple devices can have their MDM server assignment changed at once, but only a single MDM server can be specified per request.

Closes #14.