### PR TITLE
Add OpenSSL as a dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'irb'
+gem 'openssl', '~> 3.1', '>= 3.1.2' # https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
 gem 'pry'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     method_source (1.1.0)
+    openssl (3.3.2)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -93,6 +94,7 @@ PLATFORMS
 DEPENDENCIES
   axm!
   irb
+  openssl (~> 3.1, >= 3.1.2)
   pry
   rake (~> 13.0)
   rspec (~> 3.0)


### PR DESCRIPTION
OpenSSL 3.6.0 contained a change that caused some unexpected behaviour in Ruby.

OpenSSL the gem [was patched](https://github.com/ruby/openssl/issues/949#issuecomment-3370358680) to workaround the issue and released as 3.1.2, 3.2.2 and 3.3.1

